### PR TITLE
docs: update for new new extension listing guidelines/fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "debug-extension",
-  "title": "Debug extension",
   "description": "Helps debug Sourcegraph extensions",
   "publisher": "isaac",
   "activationEvents": [
     "*"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/sourcegraph-debug-extension"
+  },
+  "categories": ["Other"],
+  "tags": ["extension-dev"],
   "contributes": {
     "actions": [],
     "menus": {


### PR DESCRIPTION
Updates to reflect the changes to extension listings on the extension registry in https://github.com/sourcegraph/sourcegraph/pull/1612:

- Extensions can have tags and categories.

Also:

- Extensions no longer have titles. The extension ID, `sourcegraph/debug-extension`, and the extension description are the only things shown now. (As of https://github.com/sourcegraph/sourcegraph/pull/1613.)
- Adds the repository (which is linked to from the extension's registry listing).
